### PR TITLE
Fix icon-mui's broken readme link

### DIFF
--- a/mui/package.json
+++ b/mui/package.json
@@ -29,7 +29,7 @@
         "url": "https://github.com/brightlayer-ui/icons/issues"
     },
     "prettier": "@brightlayer-ui/prettier-config",
-    "homepage": "https://github.com/brightlayer-ui/icons/mui#readme",
+    "homepage": "https://github.com/brightlayer-ui/icons/tree/master/mui#brightlayer-ui-icons-for-mui",
     "devDependencies": {
         "@babel/cli": "^7.1.2",
         "@babel/core": "^7.1.2",


### PR DESCRIPTION
Fix it so that this thing on NPM does not point to a 404 page

![image](https://user-images.githubusercontent.com/8997218/183743002-03c246d1-c81b-4cf0-ba97-4077e306b3c1.png)
